### PR TITLE
Adding Carthage run script

### DIFF
--- a/DEV.xcodeproj/project.pbxproj
+++ b/DEV.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 				73E8C95620CB822600F9E2DE /* Frameworks */,
 				73E8C95720CB822600F9E2DE /* Resources */,
 				736BAAE32113BC5500173EC5 /* Embed Frameworks */,
+				BDC96E7E211CCB8B00A70CC7 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -294,6 +295,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		BDC96E7E211CCB8B00A70CC7 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Alamofire.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		73E8C95520CB822600F9E2DE /* Sources */ = {

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ By leveraging `wkwebviews` as much as possible, I think we can make this all pre
 # Contributing
 1. Fork and clone the project.
 2. Install [Carthage](https://github.com/Carthage/Carthage). If you use Homebrew then you can install Carthage by running `brew install carthage`. 
-2. Now run `carthage update` in the project's root directory.
-3. Follow steps 8, 9 and 10 as mentioned over [here](https://github.com/Carthage/Carthage#quick-start)
+3. Now run `carthage update` in the project's root directory.
 4. Build and run the project in XCode.
 
 # Thanks for your help!!!


### PR DESCRIPTION
Since contributors will most likely be adding the same build paths, I added the run script to the build phases. This removes a step for setup and allows for tighter management of dependencies should some be added or removed.

People prefer to manage repos differently so please comment if you disagree with these changes!