### PR TITLE
Retrieving User's Profile Image

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "Alamofire/Alamofire" ~> 4.7
+github "Alamofire/AlamofireImage" ~> 3.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
 github "Alamofire/Alamofire" "4.7.3"
+github "Alamofire/AlamofireImage" "3.4.1"

--- a/DEV.xcodeproj/project.pbxproj
+++ b/DEV.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		73E8C96920CB822600F9E2DE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 73E8C96720CB822600F9E2DE /* LaunchScreen.storyboard */; };
 		73E8C97420CB822600F9E2DE /* DEVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E8C97320CB822600F9E2DE /* DEVTests.swift */; };
 		73E8C97F20CB822600F9E2DE /* DEVUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E8C97E20CB822600F9E2DE /* DEVUITests.swift */; };
+		BD9FC4462166F88900B1C909 /* AlamofireImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD9FC4452166F88900B1C909 /* AlamofireImage.framework */; };
 		CC01F143214E8C2500871129 /* LoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01F142214E8C2500871129 /* LoginCoordinator.swift */; };
 		CC01F145214E9D0E00871129 /* CanReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC01F144214E9D0E00871129 /* CanReload.swift */; };
 		CC08F32C2134322000FB759D /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC08F3282134322000FB759D /* LoginViewController.swift */; };
@@ -85,6 +86,7 @@
 		73E8C97A20CB822600F9E2DE /* DEVUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DEVUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73E8C97E20CB822600F9E2DE /* DEVUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DEVUITests.swift; sourceTree = "<group>"; };
 		73E8C98020CB822600F9E2DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BD9FC4452166F88900B1C909 /* AlamofireImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AlamofireImage.framework; path = Carthage/Build/iOS/AlamofireImage.framework; sourceTree = "<group>"; };
 		CC01F142214E8C2500871129 /* LoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginCoordinator.swift; sourceTree = "<group>"; };
 		CC01F144214E9D0E00871129 /* CanReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanReload.swift; sourceTree = "<group>"; };
 		CC08F3282134322000FB759D /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BD9FC4462166F88900B1C909 /* AlamofireImage.framework in Frameworks */,
 				736BAAE12113BC5500173EC5 /* Alamofire.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,6 +133,7 @@
 				73E8C97220CB822600F9E2DE /* DEVTests */,
 				73E8C97D20CB822600F9E2DE /* DEVUITests */,
 				73E8C95A20CB822600F9E2DE /* Products */,
+				BD9FC4442166F88800B1C909 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -184,6 +188,14 @@
 				73E8C98020CB822600F9E2DE /* Info.plist */,
 			);
 			path = DEVUITests;
+			sourceTree = "<group>";
+		};
+		BD9FC4442166F88800B1C909 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				BD9FC4452166F88900B1C909 /* AlamofireImage.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		CC08F3272134322000FB759D /* Login */ = {
@@ -378,13 +390,15 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/AlamofireImage.framework",
 			);
 			outputPaths = (
 				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Alamofire.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/AlamofireImage.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/DEV/FirstViewController.swift
+++ b/DEV/FirstViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import WebKit
 import Alamofire
+import AlamofireImage
 
 class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
     @IBOutlet weak var webView: WKWebView!
@@ -168,6 +169,38 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
         
         if let username = user?.username {
             profileViewController.username = username
+            
+            setUserImage(forTab: profileViewController)
         }
+    }
+
+    func setUserImage(forTab profileViewController: UIViewController) {
+        
+        guard let profileImageUrl = self.user?.profileImage else { return }
+        
+        DispatchQueue.global(qos: .background).async {
+            Alamofire.request(profileImageUrl).responseImage { response in
+                
+                if let image = response.result.value {
+                    let circularImage = self.scaleImageWithRenderingMode(imageToScale: image)
+                    DispatchQueue.main.async {
+                        self.placeImageInTabBar(profileViewController, tabImage: circularImage)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func scaleImageWithRenderingMode(imageToScale: UIImage) -> UIImage {
+        let size = CGSize(width: 24.0, height: 24.0)
+        let scaledImage = imageToScale.af_imageScaled(to: size)
+        let circularImage = scaledImage.af_imageRoundedIntoCircle()
+        
+        return circularImage.withRenderingMode(.alwaysOriginal)
+    }
+    
+    private func placeImageInTabBar(_ profileViewController: UIViewController, tabImage: UIImage) {
+        let customTabBarItem = UITabBarItem(title: "DEV.self", image: tabImage, selectedImage: tabImage)
+        profileViewController.tabBarItem = customTabBarItem
     }
 }

--- a/DEV/Model/User.swift
+++ b/DEV/Model/User.swift
@@ -10,4 +10,10 @@ import Foundation
 
 struct User: Codable {
     let username: String
+    let profileImage: String
+    
+    private enum CodingKeys : String, CodingKey {
+        case username
+        case profileImage = "profile_image_90"
+    }
 }


### PR DESCRIPTION
Since the Alamofire framework is already being used I found it most fitting to use the AlamofireImage framework for this task. 

The solution is fairly straight forward, I added a new `profileImage` property to the `User` object as an alias for `profile_image_90`. After mapping the property I piggy back off of `updateProfileViewController()` to fetch the image, scale it, and create a new tab item for the profile tab.