### PR TITLE
Improving Back Button

### DIFF
--- a/DEV/ConnectViewController.swift
+++ b/DEV/ConnectViewController.swift
@@ -20,7 +20,7 @@ class ConnectViewController: UIViewController, WKNavigationDelegate, CanReload {
     override func viewDidLoad() {
         webView.navigationDelegate = self
         webView.backForwardList.perform(Selector(("_removeAllItems")))
-        webView.addObserver(self, forKeyPath: "URL", options: [.new, .old], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: [.new, .old], context: nil)
         webView.scrollView.isScrollEnabled = false
         webView.customUserAgent = "DEV-Native-iOS"
         if let authenticationURL = DevServiceURL.authentication.fullURL {
@@ -30,18 +30,11 @@ class ConnectViewController: UIViewController, WKNavigationDelegate, CanReload {
         self.Activity.startAnimating()
         self.Activity.hidesWhenStopped = true
         webView.backForwardList.perform(Selector(("_removeAllItems")))
-
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        manageBackButton()
-    }
-    
-    func manageBackButton(){
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { //race condition hack
-            self.leftButton?.isEnabled = self.webView.canGoBack
-            self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
-        }
+        leftButton?.isEnabled = webView.canGoBack
+        leftButton?.tintColor = webView.canGoBack ? .black : .clear
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/DEV/FirstViewController.swift
+++ b/DEV/FirstViewController.swift
@@ -43,13 +43,13 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
     }
     
     override func viewDidLoad() {
-        
+        leftButton.tintColor = .clear
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = true
         webView.customUserAgent = "DEV-Native-iOS"
         self.tabBarController?.delegate = UIApplication.shared.delegate as? UITabBarControllerDelegate // Needs to go in first loaded controller (this one)
         if !initialized {
-            webView.addObserver(self, forKeyPath: "URL", options: [.new, .old], context: nil)
+            webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: [.new, .old], context: nil)
             getBadgeCounts()
             initialized = true
         }
@@ -63,13 +63,11 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
         self.tabBarController?.viewControllers?.forEach {
             let _ = $0.view
         }
-        
-        
-
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        manageBackButton()
+        self.leftButton?.isEnabled = self.webView.canGoBack
+        self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -109,22 +107,12 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
                 if let user = try? JSONDecoder().decode(User.self, from: Data(jsonString.utf8)) {
                     self.user = user
                 }
-                
             }
-            
         }
-    
     }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         Activity.stopAnimating()
-    }
-    
-    func manageBackButton(){
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { //race condition hack
-            self.leftButton?.isEnabled = self.webView.canGoBack
-            self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
-        }
     }
     
     func getBadgeCounts(){

--- a/DEV/FirstViewController.swift
+++ b/DEV/FirstViewController.swift
@@ -66,8 +66,8 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        self.leftButton?.isEnabled = self.webView.canGoBack
-        self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
+        leftButton?.isEnabled = webView.canGoBack
+        leftButton?.tintColor = webView.canGoBack ? .black : .clear
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/DEV/NotificationsViewController.swift
+++ b/DEV/NotificationsViewController.swift
@@ -18,10 +18,11 @@ class NotificationsViewController: UIViewController, WKNavigationDelegate, CanRe
     }
 
     override func viewDidLoad() {
+        leftButton.tintColor = .clear
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = true
         webView.backForwardList.perform(Selector(("_removeAllItems")))
-        webView.addObserver(self, forKeyPath: "URL", options: [.new, .old], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: [.new, .old], context: nil)
         webView.customUserAgent = "DEV-Native-iOS"
         if let notificationsUrl = DevServiceURL.notification.fullURL {
             webView.load(URLRequest.init(url: notificationsUrl))
@@ -33,14 +34,8 @@ class NotificationsViewController: UIViewController, WKNavigationDelegate, CanRe
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        manageBackButton()
-    }
-    
-    func manageBackButton(){
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { //race condition hack
-            self.leftButton?.isEnabled = self.webView.canGoBack
-            self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
-        }
+        leftButton?.isEnabled = webView.canGoBack
+        leftButton?.tintColor = webView.canGoBack ? .black : .clear
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/DEV/ProfileViewController.swift
+++ b/DEV/ProfileViewController.swift
@@ -26,10 +26,11 @@ class ProfileViewController: UIViewController, WKNavigationDelegate, CanReload {
     }
     
     override func viewDidLoad() {
+        leftButton.tintColor = .clear
         webView.navigationDelegate = self
         webView.allowsBackForwardNavigationGestures = true
         webView.backForwardList.perform(Selector(("_removeAllItems")))
-        webView.addObserver(self, forKeyPath: "URL", options: [.new, .old], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.canGoBack), options: [.new, .old], context: nil)
         webView.customUserAgent = "DEV-Native-iOS"
         if let username = username, let profileURL = DevServiceURL.profile(username: username).fullURL {
             webView.load(URLRequest.init(url: profileURL))
@@ -41,16 +42,10 @@ class ProfileViewController: UIViewController, WKNavigationDelegate, CanReload {
     }
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        manageBackButton()
+        leftButton?.isEnabled = webView.canGoBack
+        leftButton?.tintColor = webView.canGoBack ? .black : .clear
     }
-    
-    func manageBackButton(){
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { //race condition hack
-            self.leftButton?.isEnabled = self.webView.canGoBack
-            self.leftButton?.tintColor = self.webView.canGoBack ? .black : .clear
-        }
-    }
-    
+   
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Activity.stopAnimating()
     }


### PR DESCRIPTION
The observer now watches for a change in the `canGoBack` property. This allows for back button management to occur only when that property changes, which should fix #38. 

If the changes are approved I'll propagate to the remaining view controllers.