### PR TITLE
Hide footer on login page so users cannot navigate without logging in

### DIFF
--- a/DEV/Login/LoginViewController.swift
+++ b/DEV/Login/LoginViewController.swift
@@ -32,10 +32,16 @@ class LoginViewController: UIViewController, WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         removeNavBar()
+        removeFooter()
     }
     
     func removeNavBar() {
         let js = "document.getElementsByClassName('top-bar')[0].style.display = 'none'"
+        webView.evaluateJavaScript(js)
+    }
+    
+    func removeFooter() {
+        let js = "document.getElementById('footer-container').style.display = 'none'"
         webView.evaluateJavaScript(js)
     }
 


### PR DESCRIPTION
To Fix https://github.com/thepracticaldev/DEV-ios/issues/46

Currently users are able to navigate the website without logging in by navigating from the footer on the login page. 

This PR hides the footer to prevent this behaviour