### PR TITLE
Issue:40 - Implemented deep link support

### DIFF
--- a/DEV/AppDelegate.swift
+++ b/DEV/AppDelegate.swift
@@ -13,7 +13,7 @@ import Alamofire
 class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarControllerDelegate {
 
     var window: UIWindow?
-
+    var deepLinkURLString: String?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -23,6 +23,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UITabBarControllerDelegat
         let theViewController = self.window?.rootViewController
         theViewController?.view.backgroundColor = UIColor (red: 253.0/255.0, green: 249.0/255.0, blue: 244.0/255.0, alpha: 1.0)
             
+        return true
+    }
+
+    // This implementation is done with following deep link URL format:
+    // `devto://dev.to/username/path-to-the-article-1a2bc`
+    public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if let scheme = url.scheme, scheme == "devto" {
+            self.deepLinkURLString = url.path
+            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: "deepLink")))
+        }
         return true
     }
 

--- a/DEV/Constants/URLConstants.swift
+++ b/DEV/Constants/URLConstants.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 DEV. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 protocol DevEndPoint {
     var fullURL: URL? { get }
@@ -21,6 +21,7 @@ enum DevServiceURL {
     case composeArticle
     case dashboard
     case login
+    case deepLink
 }
 
 extension DevServiceURL: DevEndPoint {
@@ -44,6 +45,11 @@ extension DevServiceURL: DevEndPoint {
             return URL(string: "https://dev.to/dashboard?rand=" + randomString)
         case .login:
             return URL(string: "https://dev.to/enter?rand=" + randomString)
+        case .deepLink:
+            if let urlString = (UIApplication.shared.delegate as? AppDelegate)?.deepLinkURLString {
+                return URL(string: "https://dev.to/" + urlString + "?rand=" + randomString)
+            }
+            return nil
         }
     }
 }

--- a/DEV/FirstViewController.swift
+++ b/DEV/FirstViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 import WebKit
 import Alamofire
 import AlamofireImage
+import SafariServices
 
 class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
     @IBOutlet weak var webView: WKWebView!
@@ -62,6 +63,18 @@ class FirstViewController: UIViewController, WKNavigationDelegate, CanReload {
         
         self.tabBarController?.viewControllers?.forEach {
             let _ = $0.view
+        }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(deepLinkReceived(sender:)), name: Notification.Name(rawValue: "deepLink"), object: nil)
+    }
+
+    @objc func deepLinkReceived(sender: Notification) {
+        if sender.name == Notification.Name(rawValue: "deepLink") {
+            if let deepLinkURL = DevServiceURL.deepLink.fullURL {
+                self.webView.load(URLRequest.init(url: deepLinkURL))
+                self.Activity.startAnimating()
+                self.Activity.hidesWhenStopped = true
+            }
         }
     }
     

--- a/DEV/Info.plist
+++ b/DEV/Info.plist
@@ -16,10 +16,28 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.dev.to.devto</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>devto</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -51,10 +69,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSAllowsArbitraryLoadsInWebContent</key>
-        <true/>
-    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Deep link with the URLs received with scheme devto:// instead of https://. Needs support from webpage end to provide open in app for articles. Details of webpage changes needed are mentioned in the issue linked below.

Universal links are not a part of this implementation.

Issue: https://github.com/thepracticaldev/DEV-ios/issues/40