### PR TITLE
Adding CFBundleURLTypes from previous project

### DIFF
--- a/DEV-Simple/Info.plist
+++ b/DEV-Simple/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.2</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_NAME)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>devto</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
The only difference here from the previous project is I'm using `$(PRODUCT_NAME)` instead of defining one. If you it should be different, let me know and I'll change it!

Fixes #106 