### PR TITLE
Feature/haptic feedback

### DIFF
--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -97,7 +97,7 @@
 		};
 		73D76739218BA66700BD13B6 /* Products */ = {
 			isa = PBXGroup;
-			children = (
+			children = (  
 				73D76738218BA66700BD13B6 /* DEV-Simple.app */,
 				73D7674C218BA66B00BD13B6 /* DEV-SimpleTests.xctest */,
 				73D76757218BA66B00BD13B6 /* DEV-SimpleUITests.xctest */,
@@ -504,7 +504,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = XSHX7936CA;
+				DEVELOPMENT_TEAM = "R9SWHSQNV8";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -515,7 +515,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.dev.iosm;
+				PRODUCT_BUNDLE_IDENTIFIER = to.dev.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -528,7 +528,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = XSHX7936CA;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -539,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.dev.iosm;
+				PRODUCT_BUNDLE_IDENTIFIER = to.dev.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 				73D76735218BA66700BD13B6 /* Frameworks */,
 				73D76736218BA66700BD13B6 /* Resources */,
 				73D7676C2190D8D900BD13B6 /* ShellScript */,
+				1BE5876521B1868C00CCF86E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -280,6 +281,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1BE5876521B1868C00CCF86E /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		73D7676C2190D8D900BD13B6 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -486,7 +504,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = R9SWHSQNV8;
+				DEVELOPMENT_TEAM = XSHX7936CA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -497,7 +515,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.dev.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = to.dev.iosm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -510,7 +528,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = R9SWHSQNV8;
+				DEVELOPMENT_TEAM = XSHX7936CA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -521,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.dev.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = to.dev.iosm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "R9SWHSQNV8";
+				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -528,7 +528,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "DEV-Simple/DEV-Simple.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = R9SWHSQNV8;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/DEV-Simple/ViewController.swift
+++ b/DEV-Simple/ViewController.swift
@@ -270,7 +270,6 @@ extension ViewController: WKScriptMessageHandler {
                 let notification = UINotificationFeedbackGenerator()
                 notification.notificationOccurred(.success)
             }
-            print(hapticType)
         }
     }
 }

--- a/DEV-Simple/ViewController.swift
+++ b/DEV-Simple/ViewController.swift
@@ -35,12 +35,10 @@ class ViewController: UIViewController, WKNavigationDelegate {
     var devToURL = URL(string: "https://dev.to")
 
     override func viewDidLoad() {
-        let webViewConfig = WKWebViewConfiguration()
         let contentController = WKUserContentController()
         contentController.add(self, name: "haptic")
 
-        webViewConfig.userContentController = contentController
-
+        webView.configuration.userContentController = contentController
         webView.customUserAgent = "DEV-Native-ios"
         webView.scrollView.scrollIndicatorInsets.top = view.safeAreaInsets.top + 50
 

--- a/DEV-Simple/ViewController.swift
+++ b/DEV-Simple/ViewController.swift
@@ -35,6 +35,12 @@ class ViewController: UIViewController, WKNavigationDelegate {
     var devToURL = URL(string: "https://dev.to")
 
     override func viewDidLoad() {
+        let webViewConfig = WKWebViewConfiguration()
+        let contentController = WKUserContentController()
+        contentController.add(self, name: "haptic")
+
+        webViewConfig.userContentController = contentController
+
         webView.customUserAgent = "DEV-Native-ios"
         webView.scrollView.scrollIndicatorInsets.top = view.safeAreaInsets.top + 50
 
@@ -244,5 +250,27 @@ class ViewController: UIViewController, WKNavigationDelegate {
     }
     func removeShellShadow() {
         webView.layer.shadowOpacity = 0.0
+    }
+}
+
+extension ViewController: WKScriptMessageHandler {
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == "haptic", let hapticType = message.body as? String {
+            switch hapticType {
+            case "heavy":
+                let heavyImpact = UIImpactFeedbackGenerator(style: .heavy)
+                heavyImpact.impactOccurred()
+            case "light":
+                let lightImpact = UIImpactFeedbackGenerator(style: .light)
+                lightImpact.impactOccurred()
+            case "medium":
+                let mediumImpact = UIImpactFeedbackGenerator(style: .medium)
+                mediumImpact.impactOccurred()
+            default:
+                let notification = UINotificationFeedbackGenerator()
+                notification.notificationOccurred(.success)
+            }
+            print(hapticType)
+        }
     }
 }

--- a/DEV-Simple/ViewController.swift
+++ b/DEV-Simple/ViewController.swift
@@ -35,15 +35,12 @@ class ViewController: UIViewController, WKNavigationDelegate {
     var devToURL = URL(string: "https://dev.to")
 
     override func viewDidLoad() {
-        let contentController = WKUserContentController()
-        contentController.add(self, name: "haptic")
-
-        webView.configuration.userContentController = contentController
         webView.customUserAgent = "DEV-Native-ios"
         webView.scrollView.scrollIndicatorInsets.top = view.safeAreaInsets.top + 50
 
         if let url = devToURL {
-             webView.load(URLRequest(url: url))
+            webView.load(URLRequest(url: url))
+            webView.configuration.userContentController.add(self, name: "haptic")
         }
         webView.allowsBackForwardNavigationGestures = true
         webView.navigationDelegate = self


### PR DESCRIPTION
This is a PR about the Feature Request #102 that the implementation of Haptic Feedback.

The usage of haptic feedback has been implemented using `WKWebViewConfiguration` and `WKUserContentController` to listen at the events of the webApp doing calls via `webkit.messageHandlers` on the Native side in the `ViewController` class is conforming the `WKScriptMessageHandler ` protocol to get the type of data needed to perform the actions required by the webApp.

for example if we want to have a haptic action in any place of the webApp we have 3 feedback types:

1.  heavy
2. medium
3. light

Execute the haptic we must add the following code in where we want the haptic happens:
```
<script>
 
  function hapticExampleFunction() {

      this is the main implementation the rest of the function can vary.
      window.webkit.messageHandlers.haptic.postMessage("light");
  }
  window.onload = hapticExampleFunction;

</script>
```
we could expand using the `WKScriptMessageHandler` to other webApp -> native communication because we can send JSON objects to the native side via the [WKScriptMessage](https://developer.apple.com/documentation/webkit/wkscriptmessage/1417901-body) that supports basic dataTypes.

If you have questions, let me know 

Erick
