### PR TITLE
Reachability changes

### DIFF
--- a/DEV-Simple/ViewController.swift
+++ b/DEV-Simple/ViewController.swift
@@ -59,6 +59,9 @@ class ViewController: UIViewController, WKNavigationDelegate {
             name: notificationName,
             object: nil)
 
+        }
+
+    override func viewWillAppear(_ animated: Bool) {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(reachabilityChanged),


### PR DESCRIPTION
Moved the NotificationCenter observer as recommended on the framework [instructions](https://github.com/ashleymills/Reachability.swift)  

Please check 