### PR TITLE
Add Native Refresh Button To Navigation Bar

### DIFF
--- a/DEV-Simple/storyboards/Base.lproj/Main.storyboard
+++ b/DEV-Simple/storyboards/Base.lproj/Main.storyboard
@@ -44,6 +44,12 @@
                                             <action selector="forwardButtonTapped:" destination="BYZ-38-t0r" id="SVx-iz-VOJ"/>
                                         </connections>
                                     </barButtonItem>
+                                    <barButtonItem systemItem="refresh" id="ufZ-bL-rY6">
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <connections>
+                                            <action selector="refreshButtonTapped:" destination="BYZ-38-t0r" id="0HM-2b-6FW"/>
+                                        </connections>
+                                    </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="Anc-Ki-ftU"/>
                                     <barButtonItem image="Safari" id="ax9-e8-CVX" userLabel="Safari">
                                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/DEV-Simple/views/ViewController.swift
+++ b/DEV-Simple/views/ViewController.swift
@@ -149,6 +149,10 @@ class ViewController: UIViewController {
         }
     }
 
+    @IBAction func refreshButtonTapped(_ sender: Any) {
+        webView.reload()
+    }
+
     @IBAction func safariButtonTapped(_ sender: Any) {
         openInBrowser()
     }


### PR DESCRIPTION
This PR address issue https://github.com/thepracticaldev/DEV-ios/issues/164
where the only way to refresh the current page is to do a pull-refresh. 

We are giving users an additional way to refresh the page by adding a native refresh button to the navigation bar as shown here:
![Simulator Screen Shot - iPhone 8 Plus - 2019-08-21 at 16 46 46](https://user-images.githubusercontent.com/1022275/63475654-08b98000-c43b-11e9-8b7c-990e51fa9baa.png)

I only tested this feature manually, but if you have any feedback on whether or how I should add a unit test or UI test, I welcome that. Thanks!