### PR TITLE
[#180] App crashes when DarkTheme enabled on iOS 13

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Daltron/NotificationBanner" "2.5.0"
-github "SnapKit/SnapKit" "5.0.0"
+github "SnapKit/SnapKit" "5.0.1"
 github "cbpowell/MarqueeLabel" "4.0.0"
 github "pusher/push-notifications-swift" "2.1.2"

--- a/DEV-Simple/views/ViewController.swift
+++ b/DEV-Simple/views/ViewController.swift
@@ -226,11 +226,6 @@ class ViewController: UIViewController {
     }
 
     private func applyDarkTheme() {
-        guard let statusBarView = UIApplication.shared.value(forKeyPath: "statusBarWindow.statusBar") as? UIView else {
-            return
-        }
-
-        statusBarView.backgroundColor = darkBackgroundColor
         useDarkMode = true
         setNeedsStatusBarAppearanceUpdate()
         navigationToolBar.isTranslucent = false


### PR DESCRIPTION
This PR address issue #180, setting background color manually is not needed, because status bar color is same as ViewController.view backgroundColor, tested on all supported iOS versions (11, 12, 13)
