### PR TITLE
[205] Fix colors in safe area

### DIFF
--- a/DEV-Simple/views/ViewController.swift
+++ b/DEV-Simple/views/ViewController.swift
@@ -65,6 +65,7 @@ class ViewController: UIViewController {
 
     var lightAlpha = CGFloat(0.2)
     var useDarkMode = false
+    let statusBarStyleDarkContentRawValue = 3
     let darkBackgroundColor = UIColor(red: 13/255, green: 18/255, blue: 25/255, alpha: 1)
 
     let pushNotifications = PushNotifications.shared
@@ -302,6 +303,12 @@ class ViewController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
+        if #available(iOS 13.0, *) {
+            if !useDarkMode && traitCollection.userInterfaceStyle == .dark {
+                return UIStatusBarStyle.init(rawValue: statusBarStyleDarkContentRawValue)!
+            }
+        }
+
         return useDarkMode ? .lightContent : .default
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
Fix bug where conflicts occur when users have the dark mode set for the OS and the light version of the app in their DEV settings.

## Related Tickets & Documents
#205 

## Added to documentation?
- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed