### PR TITLE
Adds Target Membership to entitlements file

### DIFF
--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		BD5C907321B645CD000D9F79 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD5C907221B645CD000D9F79 /* SnapKit.framework */; };
 		CCEA9AFC219B403100AEF5BE /* ViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA9AFB219B403100AEF5BE /* ViewControllerTests.swift */; };
 		CCEA9AFE219B410300AEF5BE /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = CCEA9AFD219B410300AEF5BE /* test.html */; };
+		DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 73D767692190CE3900BD13B6 /* DEV-Simple.entitlements */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -337,6 +338,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */,
 				1BA17C87220C8470007A8EF5 /* invertedImages.css in Resources */,
 				73D76746218BA66B00BD13B6 /* LaunchScreen.storyboard in Resources */,
 				73D76743218BA66B00BD13B6 /* Assets.xcassets in Resources */,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

It adds Target Membership assignment for the entitlements file. [Relevant SO discussion](https://stackoverflow.com/questions/41368685/xcode-8-2-cannot-set-entitlements-membership)

**Before:**

![Screen Shot 2020-02-28 at 13 44 32](https://user-images.githubusercontent.com/6045239/75587081-4bd45b80-5a3b-11ea-96c4-a3ce27d967b6.png)

**Fix:**

(add the entitlements file to "Copy Bundle Resources" in the main Target Build Phases)

![Screen Shot 2020-02-28 at 15 02 49](https://user-images.githubusercontent.com/6045239/75587192-905ff700-5a3b-11ea-926a-c70c2907717c.png)

**After:**

![Screen Shot 2020-02-28 at 15 01 00](https://user-images.githubusercontent.com/6045239/75587094-5131a600-5a3b-11ea-99bf-1a22d1cd65eb.png)


## Related Tickets & Documents

It might (hopefully) help us fix #209 

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![link surprise](https://media.giphy.com/media/1hzYVoCEc3QvHz48e6/giphy.gif)
