### PR TITLE
Removes locked screen controls when audio player is terminated

### DIFF
--- a/DEV-Simple/core/MediaManager.swift
+++ b/DEV-Simple/core/MediaManager.swift
@@ -43,6 +43,7 @@ class MediaManager: NSObject {
             avPlayer?.pause()
         case "terminate":
             avPlayer?.pause()
+            UIApplication.shared.endReceivingRemoteControlEvents()
         case "metadata":
             episodeName = message["episodeName"]
             podcastName = message["podcastName"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

When the audio player is terminated in the app the locked screen controls from `MPRemoteCommandCenter` were not removed. This means the audio player was terminated but if a user were to click on "play" using these controls the audio would start audio playback, without the audio player controls available within the app.

Luckily one line fixes this when terminating the Podcast player.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed