### PR TITLE
Native bridge metadata message support for Podcast Image URL

### DIFF
--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		CCEA9AFE219B410300AEF5BE /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = CCEA9AFD219B410300AEF5BE /* test.html */; };
 		DC0134922418621400308B7E /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 73D767692190CE3900BD13B6 /* DEV-Simple.entitlements */; };
+		DCD263752418CBC0002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
+		DCD263762418CBC1002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DCEC88492406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
 		DCEC884A2406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
 		DCEC884B2406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
@@ -440,6 +442,7 @@
 				CCEA9AFC219B403100AEF5BE /* ViewControllerTests.swift in Sources */,
 				73D76751218BA66B00BD13B6 /* DEV_SimpleTests.swift in Sources */,
 				DCEC884A2406D58C00871B95 /* MediaManager.swift in Sources */,
+				DCD263752418CBC0002FDD38 /* Bundle+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,6 +450,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DCD263762418CBC1002FDD38 /* Bundle+Extensions.swift in Sources */,
 				73D7675C218BA66B00BD13B6 /* DEV_SimpleUITests.swift in Sources */,
 				DCEC884B2406D58C00871B95 /* MediaManager.swift in Sources */,
 			);

--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		BD5C907321B645CD000D9F79 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD5C907221B645CD000D9F79 /* SnapKit.framework */; };
 		CCEA9AFC219B403100AEF5BE /* ViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA9AFB219B403100AEF5BE /* ViewControllerTests.swift */; };
 		CCEA9AFE219B410300AEF5BE /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = CCEA9AFD219B410300AEF5BE /* test.html */; };
+		DC0134922418621400308B7E /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 73D767692190CE3900BD13B6 /* DEV-Simple.entitlements */; };
 		DCEC88492406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
 		DCEC884A2406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
@@ -77,6 +78,7 @@
 		BD5C907221B645CD000D9F79 /* SnapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapKit.framework; path = Carthage/Build/iOS/SnapKit.framework; sourceTree = "<group>"; };
 		CCEA9AFB219B403100AEF5BE /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
 		CCEA9AFD219B410300AEF5BE /* test.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = test.html; sourceTree = "<group>"; };
+		DC0134912418621300308B7E /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		DCEC88482406D58C00871B95 /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -207,6 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				BD2103FD2345A5B000F1F6FB /* WKWebView+Extensions.swift */,
+				DC0134912418621300308B7E /* Bundle+Extensions.swift */,
 				BD2103FF2345A66B00F1F6FB /* Notification+Extensions.swift */,
 			);
 			path = Extensions;
@@ -421,6 +424,7 @@
 				73D7673E218BA66700BD13B6 /* ViewController.swift in Sources */,
 				DCEC88492406D58C00871B95 /* MediaManager.swift in Sources */,
 				73E8ACC72192165E009CE057 /* BrowserViewController.swift in Sources */,
+				DC0134922418621400308B7E /* Bundle+Extensions.swift in Sources */,
 				73D7673C218BA66700BD13B6 /* AppDelegate.swift in Sources */,
 				BD2104002345A66B00F1F6FB /* Notification+Extensions.swift in Sources */,
 				1B032B1821E409FE00A2108A /* Globals.swift in Sources */,

--- a/DEV-Simple/Extensions/Bundle+Extensions.swift
+++ b/DEV-Simple/Extensions/Bundle+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  Bundle+Extensions.swift
+//  DEV-Simple
+//
+//  Created by Fernando Valverde on 3/10/20.
+//  Kudos to samwize @ SO
+//  Copyright © 2020 DEV. All rights reserved.
+//
+
+import UIKit
+
+extension Bundle {
+    public var icon: UIImage? {
+        if let icons = infoDictionary?["CFBundleIcons"] as? [String: Any],
+            let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
+            let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
+            let lastIcon = iconFiles.last {
+            return UIImage(named: lastIcon)
+        }
+        return nil
+    }
+}

--- a/DEV-Simple/core/MediaManager.swift
+++ b/DEV-Simple/core/MediaManager.swift
@@ -49,12 +49,7 @@ class MediaManager: NSObject {
             avPlayer?.pause()
             UIApplication.shared.endReceivingRemoteControlEvents()
         case "metadata":
-            episodeName = message["episodeName"]
-            podcastName = message["podcastName"]
-            if let newImageUrl = message["podcastImageUrl"], newImageUrl != podcastImageUrl {
-                podcastImageUrl = newImageUrl
-                podcastImageFetched = false
-            }
+            loadMetadata(from: message)
         default:
             print("ERROR: Unknown action")
         }
@@ -106,6 +101,15 @@ class MediaManager: NSObject {
     private func rate(speed: String?) {
         guard let rateStr = speed, let rate = Float(rateStr) else { return }
         avPlayer?.rate = rate
+    }
+
+    private func loadMetadata(from message: [String: String]) {
+        episodeName = message["episodeName"]
+        podcastName = message["podcastName"]
+        if let newImageUrl = message["podcastImageUrl"], newImageUrl != podcastImageUrl {
+            podcastImageUrl = newImageUrl
+            podcastImageFetched = false
+        }
     }
 
     private func load(audioUrl: String?) {
@@ -180,7 +184,7 @@ class MediaManager: NSObject {
             return .success
         }
     }
-    
+
     private func setupInfoCenterDefaultIcon() {
         if let appIcon = Bundle.main.icon {
             let artwork = MPMediaItemArtwork(boundsSize: appIcon.size) { _ in return appIcon }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

The locked screen controls when playing a Podcast were showing the App Icon (poorly) for all Podcasts. 
This PR implements the code necessary to handle a URL sent in the `metadata` message. If no URL is received (or an invalid URL for that matter) the behavior is the same as before but slightly better.

## Related Tickets & Documents

Implements the iOS side for #218 

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

### **Before:**

![IMG_0500](https://user-images.githubusercontent.com/6045239/76368963-84a3e880-62f7-11ea-8d0d-c94f1f0615d6.PNG)

### **With this PR & no Podcast Image received:**

![IMG_0503](https://user-images.githubusercontent.com/6045239/76369753-32b09200-62fa-11ea-9ef9-997cc577ea4a.PNG)

### **With this PR & valid Podcast Image received:**

![IMG_0501](https://user-images.githubusercontent.com/6045239/76368971-8a013300-62f7-11ea-8c91-1f4c9683f9af.PNG)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
