### PR TITLE
Minor tweaks for safe area & toolbar coloring

### DIFF
--- a/DEV-Simple/storyboards/Base.lproj/Main.storyboard
+++ b/DEV-Simple/storyboards/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9JM-0s-c02">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
-                                <color key="backgroundColor" red="0.99046355490000004" green="0.97619110350000005" blue="0.95414322610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
@@ -30,7 +30,7 @@
                                 <items>
                                     <barButtonItem width="15" style="plain" systemItem="fixedSpace" id="ydj-sa-hcv"/>
                                     <barButtonItem image="chevron.left" catalog="system" width="40" id="nLO-uf-SBh" userLabel="back">
-                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
                                             <action selector="backButtonTapped:" destination="BYZ-38-t0r" id="IUB-8i-dst"/>
                                         </connections>
@@ -58,14 +58,14 @@
                                     </barButtonItem>
                                     <barButtonItem width="10" style="plain" systemItem="fixedSpace" id="tm8-h2-y0W"/>
                                 </items>
-                                <color key="barTintColor" red="0.99607843137254903" green="0.97647058823529409" blue="0.95294117647058818" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </toolbar>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="Ngy-LZ-8iC">
                                 <rect key="frame" x="169" y="315" width="37" height="37"/>
                                 <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                         </subviews>
-                        <color key="backgroundColor" red="0.98823529409999999" green="0.97647058819999999" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="9JM-0s-c02" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="N3o-VU-Bxg"/>
                             <constraint firstItem="Ngy-LZ-8iC" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="PDd-f4-juw"/>
@@ -104,7 +104,7 @@
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arP-qV-Ajc">
                                 <rect key="frame" x="0.0" y="56" width="375" height="591"/>
-                                <color key="backgroundColor" red="0.99046355490000004" green="0.97619110350000005" blue="0.95414322610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" red="0.97647058823529409" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>
@@ -117,7 +117,7 @@
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tpz-av-3nB">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="barTintColor" red="0.99607843137254903" green="0.97647058823529409" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <items>
                                     <navigationItem id="sH5-rC-oI7">
                                         <barButtonItem key="leftBarButtonItem" title="Item" image="xmark" catalog="system" id="Pgw-e8-VV1">

--- a/DEV-Simple/storyboards/Base.lproj/Main.storyboard
+++ b/DEV-Simple/storyboards/Base.lproj/Main.storyboard
@@ -104,7 +104,7 @@
                         <subviews>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arP-qV-Ajc">
                                 <rect key="frame" x="0.0" y="56" width="375" height="591"/>
-                                <color key="backgroundColor" red="0.97647058823529409" green="0.98039215686274506" blue="0.98039215686274506" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences"/>

--- a/DEV-Simple/storyboards/Base.lproj/Main.storyboard
+++ b/DEV-Simple/storyboards/Base.lproj/Main.storyboard
@@ -134,7 +134,7 @@
                                 </items>
                             </navigationBar>
                         </subviews>
-                        <color key="backgroundColor" red="0.98823529409999999" green="0.97647058819999999" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="arP-qV-Ajc" firstAttribute="leading" secondItem="29u-q3-2SN" secondAttribute="leading" id="5Km-PG-rx3"/>
                             <constraint firstItem="arP-qV-Ajc" firstAttribute="trailing" secondItem="29u-q3-2SN" secondAttribute="trailing" id="H9D-Mv-QBR"/>

--- a/DEV-Simple/views/ViewController.swift
+++ b/DEV-Simple/views/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
     var lightAlpha = CGFloat(0.2)
     var useDarkMode = false
     let statusBarStyleDarkContentRawValue = 3
-    let darkBackgroundColor = UIColor(red: 13/255, green: 18/255, blue: 25/255, alpha: 1)
+    let darkBackgroundColor = UIColor(red: 26/255, green: 38/255, blue: 52/255, alpha: 1)
 
     let pushNotifications = PushNotifications.shared
     lazy var errorBanner: NotificationBanner = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

With Crayons out in production these changes make sure the safe area and toolbar are displayed accordingly.

## Related Tickets & Documents

[Crayons'ifizing Header](https://github.com/thepracticaldev/dev.to/pull/6780)

# Before Screenshots 👇🏼

![before_default](https://user-images.githubusercontent.com/6045239/77691096-f3c14400-6f69-11ea-8a4d-41e789a4b79d.png)
_Feed before_ 

![before_default2](https://user-images.githubusercontent.com/6045239/77691102-f6239e00-6f69-11ea-98d0-4533847ba022.png)
_Browser view before_ 

![before_dark](https://user-images.githubusercontent.com/6045239/77691115-fc197f00-6f69-11ea-92fc-1b8fc1d65b8b.png)
_Dark Feed before_ 

# After Screenshots 👇🏼

![after_default](https://user-images.githubusercontent.com/6045239/77691480-9a0d4980-6f6a-11ea-920b-a90c1b6107c4.png)
_Feed after_

![after_default2](https://user-images.githubusercontent.com/6045239/77691626-e22c6c00-6f6a-11ea-8732-1fe502a2f93a.png)
_Browser view after_

![after_dark](https://user-images.githubusercontent.com/6045239/77691171-105d7c00-6f6a-11ea-992f-2ff5262fa1c4.png)
_Dark Feed after_

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

