### PR TITLE
Better handling of podcast metadata for locked screen artwork

### DIFF
--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		DC0134922418621400308B7E /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 73D767692190CE3900BD13B6 /* DEV-Simple.entitlements */; };
 		DC8C833A244D7F100081F6CE /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8339244D7F100081F6CE /* URL+Extensions.swift */; };
+		DC8C833B244D8A0A0081F6CE /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8339244D7F100081F6CE /* URL+Extensions.swift */; };
+		DC8C833C244D8A0B0081F6CE /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8339244D7F100081F6CE /* URL+Extensions.swift */; };
 		DCD263752418CBC0002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DCD263762418CBC1002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DCEC88492406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
@@ -445,6 +447,7 @@
 			files = (
 				CCEA9AFC219B403100AEF5BE /* ViewControllerTests.swift in Sources */,
 				73D76751218BA66B00BD13B6 /* DEV_SimpleTests.swift in Sources */,
+				DC8C833B244D8A0A0081F6CE /* URL+Extensions.swift in Sources */,
 				DCEC884A2406D58C00871B95 /* MediaManager.swift in Sources */,
 				DCD263752418CBC0002FDD38 /* Bundle+Extensions.swift in Sources */,
 			);
@@ -455,6 +458,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DCD263762418CBC1002FDD38 /* Bundle+Extensions.swift in Sources */,
+				DC8C833C244D8A0B0081F6CE /* URL+Extensions.swift in Sources */,
 				73D7675C218BA66B00BD13B6 /* DEV_SimpleUITests.swift in Sources */,
 				DCEC884B2406D58C00871B95 /* MediaManager.swift in Sources */,
 			);

--- a/DEV-Simple.xcodeproj/project.pbxproj
+++ b/DEV-Simple.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		CCEA9AFE219B410300AEF5BE /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = CCEA9AFD219B410300AEF5BE /* test.html */; };
 		DC0134922418621400308B7E /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DC7C024C2409AAE100926396 /* DEV-Simple.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 73D767692190CE3900BD13B6 /* DEV-Simple.entitlements */; };
+		DC8C833A244D7F100081F6CE /* URL+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8C8339244D7F100081F6CE /* URL+Extensions.swift */; };
 		DCD263752418CBC0002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DCD263762418CBC1002FDD38 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0134912418621300308B7E /* Bundle+Extensions.swift */; };
 		DCEC88492406D58C00871B95 /* MediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCEC88482406D58C00871B95 /* MediaManager.swift */; };
@@ -81,6 +82,7 @@
 		CCEA9AFB219B403100AEF5BE /* ViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerTests.swift; sourceTree = "<group>"; };
 		CCEA9AFD219B410300AEF5BE /* test.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = test.html; sourceTree = "<group>"; };
 		DC0134912418621300308B7E /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		DC8C8339244D7F100081F6CE /* URL+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extensions.swift"; sourceTree = "<group>"; };
 		DCEC88482406D58C00871B95 /* MediaManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -212,6 +214,7 @@
 			children = (
 				BD2103FD2345A5B000F1F6FB /* WKWebView+Extensions.swift */,
 				DC0134912418621300308B7E /* Bundle+Extensions.swift */,
+				DC8C8339244D7F100081F6CE /* URL+Extensions.swift */,
 				BD2103FF2345A66B00F1F6FB /* Notification+Extensions.swift */,
 			);
 			path = Extensions;
@@ -430,6 +433,7 @@
 				73D7673C218BA66700BD13B6 /* AppDelegate.swift in Sources */,
 				BD2104002345A66B00F1F6FB /* Notification+Extensions.swift in Sources */,
 				1B032B1821E409FE00A2108A /* Globals.swift in Sources */,
+				DC8C833A244D7F100081F6CE /* URL+Extensions.swift in Sources */,
 				BD5C906C21B63CCC000D9F79 /* NetworkReachability.swift in Sources */,
 				BD2103FE2345A5B000F1F6FB /* WKWebView+Extensions.swift in Sources */,
 			);

--- a/DEV-Simple/Extensions/URL+Extensions.swift
+++ b/DEV-Simple/Extensions/URL+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  URL+Extensions.swift
+//  DEV-Simple
+//
+//  Created by Fernando Valverde on 4/20/20.
+//  Copyright © 2020 DEV. All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+    public static func from(urlString: String?, defaultHost: String) -> URL? {
+        var resolvedURL: URL?
+        if let urlString = urlString {
+            resolvedURL = URL(string: urlString)
+            // On local development the url might be relative and this check ensures an absolute URL
+            if resolvedURL?.host == nil {
+                resolvedURL = URL(string: "\(defaultHost)\(urlString)")
+            }
+        }
+        return resolvedURL
+    }
+}

--- a/DEV-Simple/core/MediaManager.swift
+++ b/DEV-Simple/core/MediaManager.swift
@@ -209,15 +209,7 @@ class MediaManager: NSObject {
     }
 
     private func fetchRemoteArtwork() {
-        var resolvedURL: URL?
-        if let podcastImageUrl = podcastImageUrl {
-            resolvedURL = URL(string: podcastImageUrl)
-            // On local development the url might be relative and this check ensures an absolute URL
-            if resolvedURL?.host == nil {
-                resolvedURL = URL(string: "\(devToURL)\(podcastImageUrl)")
-            }
-        }
-        if let resolvedURL = resolvedURL {
+        if let resolvedURL = URL.from(urlString: podcastImageUrl, defaultHost: devToURL) {
             let task = URLSession.shared.dataTask(with: resolvedURL) { data, response, error in
                 guard error == nil, let data = data,
                     let mimeType = response?.mimeType, mimeType.contains("image/"),

--- a/DEV-Simple/views/ViewController.swift
+++ b/DEV-Simple/views/ViewController.swift
@@ -78,7 +78,7 @@ class ViewController: UIViewController {
     }()
 
     lazy var mediaManager: MediaManager = {
-        return MediaManager(webView: self.webView)
+        return MediaManager(webView: self.webView, devToURL: self.devToURL)
     }()
 
     var devToURL: String = {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Documentation Update

## Description

Since [7303](https://github.com/thepracticaldev/dev.to/pull/7303) was merged we will get relative paths for Podcast metadata when working on development. The PR handles relative paths in a separate function.

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
