### PR TITLE
Adds init msg and enhancements for the UX of the Podcast Player

### DIFF
--- a/DEV-Simple/core/MediaManager.swift
+++ b/DEV-Simple/core/MediaManager.swift
@@ -62,7 +62,7 @@ class MediaManager: NSObject {
     // MARK: - Action Functions
 
     private func play(audioUrl: String?, at seconds: String?) {
-        guard let secondsStr = seconds, var seconds = Double(secondsStr) else { return }
+        var seconds = Double(seconds ?? "0")
         if currentPodcastURL != audioUrl && audioUrl != nil {
             avPlayer?.pause()
             seconds = 0
@@ -71,7 +71,7 @@ class MediaManager: NSObject {
         }
 
         guard avPlayer?.timeControlStatus != .playing else { return }
-        avPlayer?.seek(to: CMTime(seconds: seconds, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
+        avPlayer?.seek(to: CMTime(seconds: seconds ?? 0, preferredTimescale: CMTimeScale(NSEC_PER_SEC)))
         avPlayer?.play()
         updateNowPlayingInfoCenter()
         setupNowPlayingInfoCenter()
@@ -110,13 +110,15 @@ class MediaManager: NSObject {
     }
 
     private func rate(speed: String?) {
-        guard let rateStr = speed, let rate = Float(rateStr) else { return }
-        avPlayer?.rate = rate
+        if let rate = Float(speed ?? "1") {
+            avPlayer?.rate = rate
+        }
     }
 
     private func volume(percentage: String?) {
-        guard let volumeStr = percentage, let volume = Float(volumeStr) else { return }
-        avPlayer?.volume = volume
+        if let volume = Float(percentage ?? "1") {
+            avPlayer?.volume = volume
+        }
     }
 
     private func loadMetadata(from message: [String: String]) {

--- a/DEV-Simple/core/MediaManager.swift
+++ b/DEV-Simple/core/MediaManager.swift
@@ -93,20 +93,21 @@ class MediaManager: NSObject {
         let newTime = playerCurrentTime + 15
 
         if newTime < (CMTimeGetSeconds(duration) - 15) {
-            let time2: CMTime = CMTimeMake(value: Int64(newTime * 1000 as Float64), timescale: 1000)
-            avPlayer!.seek(to: time2, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
+            avPlayer!.seek(to: seekableTime(newTime), toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
         }
     }
 
     private func seekBackward(_ sender: Any) {
         let playerCurrentTime = CMTimeGetSeconds(avPlayer!.currentTime())
         var newTime = playerCurrentTime - 15
-
         if newTime < 0 {
             newTime = 0
         }
-        let time2: CMTime = CMTimeMake(value: Int64(newTime * 1000 as Float64), timescale: 1000)
-        avPlayer!.seek(to: time2, toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
+        avPlayer!.seek(to: seekableTime(newTime), toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero)
+    }
+
+    private func seekableTime(_ seconds: Double) -> CMTime {
+        return CMTimeMake(value: Int64(seconds * 1000 as Float64), timescale: 1000)
     }
 
     private func loadMetadata(from message: [String: String]) {


### PR DESCRIPTION
<!--- Prepend PR title with [WIP] if work in progress. Remove when ready for review. -->

<!--- For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments -->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description

This PR changes a few things in the way Podcasts are being played:
- Adds the `init` message to enhance the experience when switching between Podcasts: Shows `initializing...` label in the UI controls instead of badly formatted time stamps.
- Fixes a bug that happened when playing a Podcast Episode and the user wants to play a different one, they would need to terminate (close with `x` button) before being able to play the next one: They can just `play` any episode, no matter if they were previously listening to another one.
- Adds support for `volume` message. iPhones don't need this because they only have the mute capability, but iPads may use this feature (hover will present the volume slider)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![better](https://media.giphy.com/media/l0HlOGsDTZTaOTVba/giphy.gif)
